### PR TITLE
Revitalization plan: phased checklist for modernizing the Pi uploader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# Claude Agent Instructions
+
+This repository is a Raspberry Pi photo uploader that captures images at dawn/dusk intervals and uploads them to an Amazon S3 bucket. The codebase dates from 2020 and is undergoing a phased revitalization tracked in `REVITALIZATION.md`.
+
+## Working on this project
+
+All planned work is tracked in `REVITALIZATION.md`. Before starting any task:
+
+1. Find the relevant item(s) in the checklist
+2. Update the `State` column to `in-progress`
+3. Do the work on the `claude/raspi-s3-uploader-review-R1kBl` branch (or a branch per phase)
+4. Update the `State` column to `done` when the work is merged
+
+### State values
+
+| Value | Meaning |
+|-------|---------|
+| `todo` | Not started |
+| `in-progress` | Actively being worked |
+| `done` | Completed and merged |
+| `stalled` | Started but stuck — leave a note in the Notes column |
+| `blocked` | Waiting on something external — describe what in the Notes column |
+| `wont-fix` | Decided not to address — explain why in the Notes column |
+
+## Project structure
+
+```
+pi-pic-script/
+  pic-script.py       # main entry point — runs on the Pi
+  test2.py            # dev scaffolding (to be deleted, Phase 3.5)
+  utils/
+    s3_utils.py       # clearBucket() helper — currently unused (Phase 3.4)
+    time_utils.py     # getDayLight() — broken return value (Phase 3.2)
+datetime_astral_test.py  # standalone astral smoke test (Phase 3.6)
+keys.sh                  # SECURITY ISSUE — to be deleted (Phase 1.1)
+requirements.txt         # outdated deps, needs full regeneration (Phase 2.4)
+REVITALIZATION.md        # phased checklist
+```
+
+## Priority order
+
+Work phases in this order — later phases depend on earlier ones being stable:
+
+1. **Phase 1 (Security)** — must be done before anything is deployed
+2. **Phase 2 (Runtime)** — Python + library upgrades unblock everything else
+3. **Phase 3 (Core logic)** — fix the dangerous bucket-wipe and dead code
+4. **Phase 4 (Reliability)** — logging and error handling
+5. **Phase 5 (Config)** — extract hardcoded values
+6. **Phase 6 (systemd)** — deployment wiring
+7. **Phase 7 (Enhancements)** — optional, do last
+
+## Critical context
+
+- **`bucket.objects.all().delete()` runs on every photo upload** (`pic-script.py` ~line 39). The entire S3 bucket is wiped every 30 minutes. Fix: upload to a fixed key (`public/current.jpg`) and overwrite in place — no deletion needed.
+- **`keys.sh` contains AWS credential handling that exposes secrets in the process list.** Treat the key pair as compromised and rotate it before any other work.
+- **`astral` 1.x → 3.x is a breaking API change.** The `Location` class and `sun()` call signatures changed. Read the astral 3.x docs before touching `time_utils.py` or the main script.
+- **`picamera` is deprecated** on Raspberry Pi OS Bookworm and later. Use `picamera2`.
+
+## Running the code
+
+The main script requires Pi hardware (camera module) and valid AWS credentials. For development and testing without hardware:
+
+- Comment out the `PiCamera` block (as done in `test2.py`) to test S3 logic
+- Use `datetime_astral_test.py` to validate sun-timing logic without S3 or camera
+- Set `AWS_PROFILE` or populate `~/.aws/credentials` before running any S3 code

--- a/REVITALIZATION.md
+++ b/REVITALIZATION.md
@@ -1,0 +1,85 @@
+# Revitalization Checklist
+
+Tracks all identified issues and improvements for the `s3-sunriver-upload` Raspberry Pi photo uploader.
+
+**State values:** `todo` · `in-progress` · `done` · `stalled` · `blocked` · `wont-fix`
+
+---
+
+## Phase 1 — Security & Credentials
+
+| # | Task | State | Notes |
+|---|------|-------|-------|
+| 1.1 | Remove `keys.sh` from repo and git history | `todo` | Credentials were passed as CLI args, visible in process list and bash history |
+| 1.2 | Rotate the AWS credentials that were committed | `todo` | Treat as compromised; generate new key pair in IAM |
+| 1.3 | Switch to `~/.aws/credentials` file or IAM role auth | `todo` | Never pass secrets as arguments or env vars set in scripts |
+| 1.4 | Scope IAM policy to minimum required permissions | `todo` | Only `s3:PutObject` + `s3:DeleteObject` on `sunriver-display-s3-prod/public/*` |
+
+---
+
+## Phase 2 — Modernize the Runtime
+
+| # | Task | State | Notes |
+|---|------|-------|-------|
+| 2.1 | Upgrade to Python 3.11 or 3.12 | `todo` | Currently pinned to Python 3.5.3 (EOL Oct 2020) |
+| 2.2 | Migrate from `astral` 1.x to 3.x | `todo` | Breaking API change — location and sun() interfaces changed significantly |
+| 2.3 | Replace `picamera` with `picamera2` | `todo` | `picamera` is deprecated on modern Pi OS (Bookworm+) |
+| 2.4 | Regenerate `requirements.txt` with current pinned versions | `todo` | boto3, botocore, pytz, python-dateutil all need updates |
+| 2.5 | Add `pyvenv.cfg` to `.gitignore` | `todo` | Virtual environment config should not be in source control |
+
+---
+
+## Phase 3 — Fix Core Logic
+
+| # | Task | State | Notes |
+|---|------|-------|-------|
+| 3.1 | Replace bucket-wipe-on-upload with fixed key overwrite | `todo` | `bucket.objects.all().delete()` on every photo is destructive; upload to `public/current.jpg` instead |
+| 3.2 | Fix `time_utils.getDayLight()` return value | `todo` | Function returns the location object instead of the sun timing dict — broken/dead code |
+| 3.3 | Wire `time_utils` into main script or delete it | `todo` | Currently unused; duplicated inline in `pic-script.py` |
+| 3.4 | Delete `s3_utils.py` or use it | `todo` | `clearBucket()` was extracted but never imported; orphaned dead code |
+| 3.5 | Delete `test2.py` and `test.txt` | `todo` | Leftover development scaffolding committed to repo |
+| 3.6 | Remove or fix `datetime_astral_test.py` | `todo` | Decide if this becomes a proper test or gets deleted |
+
+---
+
+## Phase 4 — Reliability & Observability
+
+| # | Task | State | Notes |
+|---|------|-------|-------|
+| 4.1 | Replace `print()` with `logging` module | `todo` | Logs go nowhere once terminal is closed; use rotating file handler at `/var/log/sunriver-upload.log` |
+| 4.2 | Add try/except around camera capture with retry | `todo` | Camera failures silently crash the script |
+| 4.3 | Add try/except around S3 upload with exponential backoff | `todo` | Network dropouts and S3 throttling cause silent crashes; 3 retries recommended |
+| 4.4 | Add SIGTERM / SIGINT signal handling for graceful shutdown | `todo` | Mid-upload interruption can leave bucket in partial state |
+| 4.5 | Add error handling around astral dawn/dusk calculation | `todo` | `astral` can throw on edge-case dates/coordinates |
+
+---
+
+## Phase 5 — Configurability
+
+| # | Task | State | Notes |
+|---|------|-------|-------|
+| 5.1 | Extract all hardcoded values to a config file | `todo` | Bucket name, prefix, lat/lon, timezone, resolution, interval, filename template are all buried in script body |
+| 5.2 | Choose config mechanism (`.env`, `config.ini`, or `config.py`) | `todo` | `.env` + `python-dotenv` is common; `configparser` + `.ini` is zero-dependency |
+| 5.3 | Add `.env.example` or `config.example.ini` to repo | `todo` | Document required config keys so setup is self-explanatory |
+
+---
+
+## Phase 6 — Run as a systemd Service
+
+| # | Task | State | Notes |
+|---|------|-------|-------|
+| 6.1 | Write `sunriver-upload.service` systemd unit file | `todo` | Enables start-on-boot and automatic restart on crash |
+| 6.2 | Set `Restart=on-failure` with a restart delay | `todo` | Prevents rapid crash loops |
+| 6.3 | Write installation / deployment instructions in README | `todo` | Document `systemctl enable`, credential setup, and config steps |
+
+---
+
+## Phase 7 — Optional Enhancements
+
+| # | Task | State | Notes |
+|---|------|-------|-------|
+| 7.1 | Add photo archive alongside current.jpg | `todo` | Upload to `archive/YYYY/MM/DD/HH-MM.jpg` in addition to overwriting `current.jpg`; enables time-lapse later |
+| 7.2 | Upload a heartbeat/health file to S3 each cycle | `todo` | Allows external uptime monitoring without SSH access to the Pi |
+| 7.3 | Improve image quality settings for picamera2 | `todo` | HDR, white balance, and exposure controls available in picamera2 |
+| 7.4 | Add GitHub Actions CI (lint + test) | `todo` | `ruff` for linting, `pytest` for unit tests, run on push to catch regressions before deploy |
+| 7.5 | Write unit tests for time/sun logic | `todo` | `time_utils` logic is testable without hardware; mock astral calls |


### PR DESCRIPTION
## Summary

Full audit of the 2020-era Raspberry Pi photo uploader codebase. This PR adds `REVITALIZATION.md` — a phased, agent-trackable checklist of every issue found and improvement planned.

## What's in the checklist

- **Phase 1 — Security**: Remove committed `keys.sh`, rotate credentials, switch to IAM role auth, scope IAM policy
- **Phase 2 — Runtime**: Upgrade Python 3.5.3 → 3.12, migrate `astral` 1.x → 3.x, replace deprecated `picamera` with `picamera2`
- **Phase 3 — Core logic**: Fix the `bucket.objects.all().delete()` on every upload, fix broken `time_utils` return value, delete dead code (`s3_utils.py`, `test2.py`, `test.txt`)
- **Phase 4 — Reliability**: Add `logging`, try/except + retry around camera and S3, signal handling for graceful shutdown
- **Phase 5 — Config**: Extract all hardcoded values (bucket, lat/lon, interval, etc.) to a config file
- **Phase 6 — systemd**: Write a service unit file for start-on-boot and crash recovery
- **Phase 7 — Optional**: Photo archive, heartbeat file, CI with ruff + pytest

## How to use this checklist

Each row has a **State** column. Update it as work progresses:

| Value | Meaning |
|-------|---------|
| `todo` | Not started |
| `in-progress` | Actively being worked |
| `done` | Completed and merged |
| `stalled` | Started but stuck |
| `blocked` | Waiting on something external |
| `wont-fix` | Decided not to address |

Agents or contributors working on a phase should update the state column in a follow-up commit/PR so the checklist stays current.

## Notable critical findings

- `bucket.objects.all().delete()` runs on **every photo upload** — the entire bucket is wiped every 30 minutes
- AWS credentials were passed as CLI arguments (visible in `ps aux` and bash history)
- Python 3.5.3 has been end-of-life since October 2020; 10 known vulnerabilities flagged by Dependabot on the current dep set

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVgBdCCYNVveyeKzM7s8au)_