### PR TITLE
security(1.1): remove keys.sh

### DIFF
--- a/REVITALIZATION.md
+++ b/REVITALIZATION.md
@@ -10,7 +10,7 @@ Tracks all identified issues and improvements for the `s3-sunriver-upload` Raspb
 
 | # | Task | State | Notes |
 |---|------|-------|-------|
-| 1.1 | Remove `keys.sh` from repo and git history | `todo` | Credentials were passed as CLI args, visible in process list and bash history |
+| 1.1 | Remove `keys.sh` from repo and git history | `in-progress` | Credentials were passed as CLI args, visible in process list and bash history |
 | 1.2 | Rotate the AWS credentials that were committed | `todo` | Treat as compromised; generate new key pair in IAM |
 | 1.3 | Switch to `~/.aws/credentials` file or IAM role auth | `todo` | Never pass secrets as arguments or env vars set in scripts |
 | 1.4 | Scope IAM policy to minimum required permissions | `todo` | Only `s3:PutObject` + `s3:DeleteObject` on `sunriver-display-s3-prod/public/*` |

--- a/keys.sh
+++ b/keys.sh
@@ -1,2 +1,0 @@
-export AWS_ACCESS_KEY_ID=$1
-export AWS_SECRET_ACCESS_KEY=$2


### PR DESCRIPTION
## Summary

`keys.sh` passed AWS credentials as positional CLI arguments:

```bash
export AWS_ACCESS_KEY_ID=$1
export AWS_SECRET_ACCESS_KEY=$2
```

This means every invocation like `source keys.sh AKIA... secret...` exposes the key ID and secret in:
- `ps aux` output (visible to any user on the system while the command runs)
- bash history (`~/.bash_history`)
- any terminal session recording or audit log

## What this PR does

- Deletes `keys.sh` from the repository tree going forward
- Updates `REVITALIZATION.md` row 1.1 state from `todo` to `in-progress`

## What this PR does NOT do

A full git history rewrite to scrub `keys.sh` from all past commits is **not included here** — that requires running [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) or `git filter-repo` and then force-pushing, which requires coordination with all contributors. The repo owner should perform this as a separate manual step after merging.

**The credentials that were committed should be treated as compromised and rotated in AWS IAM regardless of whether the history is rewritten** (see Phase 1.2).

https://claude.ai/code/session_01PVgBdCCYNVveyeKzM7s8au

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVgBdCCYNVveyeKzM7s8au)_