### PR TITLE
docs: add no-direct-push-to-master rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,23 @@
 
 This repository is a Raspberry Pi photo uploader that captures images at dawn/dusk intervals and uploads them to an Amazon S3 bucket. The codebase dates from 2020 and is undergoing a phased revitalization tracked in `REVITALIZATION.md`.
 
+## Git rules
+
+**Never push directly to `master`.** All changes must go through a pull request. Always:
+
+1. Create a feature branch: `git checkout -b <branch-name>`
+2. Commit changes there
+3. Push the branch and open a PR
+4. Wait for the PR to be merged — do not push the changes to `master` yourself
+
 ## Working on this project
 
 All planned work is tracked in `REVITALIZATION.md`. Before starting any task:
 
 1. Find the relevant item(s) in the checklist
 2. Update the `State` column to `in-progress`
-3. Do the work on the `claude/raspi-s3-uploader-review-R1kBl` branch (or a branch per phase)
-4. Update the `State` column to `done` when the work is merged
+3. Create a branch named after the task (e.g. `revitalize/3.1-fix-bucket-wipe`)
+4. Update the `State` column to `done` when the PR is merged
 
 ### State values
 


### PR DESCRIPTION
## What

Adds a prominent **Git rules** section to `CLAUDE.md` instructing agents to never push directly to `master` — all changes must go through a PR.

## Why

One of the parallel agents pushed a change directly to `master` during the revitalization work instead of going through a PR. This instruction makes the expected workflow explicit so future agents don't repeat it.

## Note

This is a soft guardrail (instruction-level). For a hard guardrail that actually blocks direct pushes, enable **branch protection** on `master` in GitHub Settings → Branches → Add ruleset, and check "Require a pull request before merging".

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVgBdCCYNVveyeKzM7s8au)_