### PR TITLE
chore(3.4): delete orphaned s3_utils.py

### DIFF
--- a/REVITALIZATION.md
+++ b/REVITALIZATION.md
@@ -36,7 +36,7 @@ Tracks all identified issues and improvements for the `s3-sunriver-upload` Raspb
 | 3.1 | Replace bucket-wipe-on-upload with fixed key overwrite | `done` | `bucket.objects.all().delete()` on every photo is destructive; upload to `public/current.jpg` instead |
 | 3.2 | Fix `time_utils.getDayLight()` return value | `in-progress` | Function returns the location object instead of the sun timing dict — broken/dead code |
 | 3.3 | Wire `time_utils` into main script or delete it | `todo` | Currently unused; duplicated inline in `pic-script.py` |
-| 3.4 | Delete `s3_utils.py` or use it | `todo` | `clearBucket()` was extracted but never imported; orphaned dead code |
+| 3.4 | Delete `s3_utils.py` or use it | `in-progress` | `clearBucket()` was extracted but never imported; orphaned dead code |
 | 3.5 | Delete `test2.py` and `test.txt` | `done` | Leftover development scaffolding committed to repo |
 | 3.6 | Remove or fix `datetime_astral_test.py` | `todo` | Decide if this becomes a proper test or gets deleted |
 

--- a/pi-pic-script/utils/s3_utils.py
+++ b/pi-pic-script/utils/s3_utils.py
@@ -1,8 +1,0 @@
-
-def clearBucket(bucket):
-    keys = []
-    for s3_file in bucket.objects.all():
-        keys.append({'Key': s3_file.key})
-    bucket.delete_objects(Delete={
-        'Objects': keys
-    })


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `pi-pic-script/utils/s3_utils.py` defined a `clearBucket()` helper that was extracted into a utility module but never imported or called anywhere in the codebase.
- The main script (`pic-script.py`) handled bucket deletion inline via `bucket.objects.all().delete()` — that inline deletion has been replaced with a fixed-key overwrite in PR #4, making this helper even more redundant.
- With no callers and no planned use, this file is pure dead code. Removing it reduces confusion about whether `clearBucket()` is the intended deletion path.

## Test plan

- [ ] Confirm `pi-pic-script/utils/s3_utils.py` is absent from the tree after merge
- [ ] Confirm no other file imports from `s3_utils` (grep shows no references)
- [ ] Verify `pic-script.py` still functions correctly (bucket deletion was already removed in PR #4)

https://claude.ai/code/session_01PVgBdCCYNVveyeKzM7s8au
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVgBdCCYNVveyeKzM7s8au)_