### PR TITLE
feat(2.3): replace picamera with picamera2

### DIFF
--- a/REVITALIZATION.md
+++ b/REVITALIZATION.md
@@ -23,7 +23,7 @@ Tracks all identified issues and improvements for the `s3-sunriver-upload` Raspb
 |---|------|-------|-------|
 | 2.1 | Upgrade to Python 3.11 or 3.12 | `todo` | Currently pinned to Python 3.5.3 (EOL Oct 2020) |
 | 2.2 | Migrate from `astral` 1.x to 3.x | `todo` | Breaking API change — location and sun() interfaces changed significantly |
-| 2.3 | Replace `picamera` with `picamera2` | `todo` | `picamera` is deprecated on modern Pi OS (Bookworm+) |
+| 2.3 | Replace `picamera` with `picamera2` | `in-progress` | `picamera` is deprecated on modern Pi OS (Bookworm+) |
 | 2.4 | Regenerate `requirements.txt` with current pinned versions | `todo` | boto3, botocore, pytz, python-dateutil all need updates |
 | 2.5 | Add `pyvenv.cfg` to `.gitignore` | `done` | Virtual environment config should not be in source control |
 

--- a/pi-pic-script/pic-script.py
+++ b/pi-pic-script/pic-script.py
@@ -1,7 +1,7 @@
 import boto3
 import os
 from time import sleep, strftime
-from picamera import PiCamera
+from picamera2 import Picamera2
 import datetime
 import pytz
 import astral
@@ -12,8 +12,9 @@ l = astral.Location((city_name, 'USA', 43.8694, -121.4334, 'US/Pacific', 4164)) 
 
 pst=pytz.timezone('US/Pacific')
 
-camera = PiCamera()
-camera.resolution = (1024, 768)
+camera = Picamera2()
+camera.configure(camera.create_still_configuration(main={"size": (1024, 768)}))
+camera.start()
 
 bucketName = 'sunriver-display-s3-prod'
 s3 = boto3.resource('s3')
@@ -33,8 +34,7 @@ while 1:
             print('Sun is up take a photo. Count: %s' % (str(pictures)))
             timeStamp = strftime("%Y-%m-%d_%X")     # YYYY-mm-dd_time
             fileName = '8_towhee_' + timeStamp + '.jpg'
-            camera.annotate_text = fileName
-            camera.capture(fileName)
+            camera.capture_file(fileName)
 
             bucket.upload_file(fileName, 'public/current.jpg')
             os.remove(fileName)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# picamera2 is NOT installed via pip — use: sudo apt install python3-picamera2
+# See: https://datasheets.raspberrypi.com/camera/picamera2-manual.pdf
 astral==1.10.1
 boto3==1.11.9
 botocore==1.14.9


### PR DESCRIPTION
## Closing — changes already in master

All picamera2 code changes (`Picamera2` import, `configure`/`start`, `capture_file`, `annotate_text` removal, `requirements.txt` comment) landed in master as part of the PR #11 (astral 3.x migration) merge. The `REVITALIZATION.md` row 2.3 is already marked `in-progress` on master.

Nothing left to merge from this branch.